### PR TITLE
Implement first opcodes and test them :syringe: 

### DIFF
--- a/chip8-core/src/lib.rs
+++ b/chip8-core/src/lib.rs
@@ -115,7 +115,7 @@ impl Emu {
         #[allow(clippy::match_single_binding)]
         match (digit1, digit2, digit3, digit4) {
             // 0000 -- NOP
-            (0, 0, 0, 0) => return,
+            (0, 0, 0, 0) => (),
             // 00E0 -- CLS
             (0, 0, 0xE, 0) => {
                 self.screen = [false; SCREEN_WIDTH * SCREEN_HEIGHT];


### PR DESCRIPTION
Implemented and tested:
- 0x000 (nop)
- 0x00E0 (cls)
- 0x00EE (ret)
- 1NNN (jump)
- 2NNN (call)
- 3NNN (skip next if VX=NN)
- BNNN (jump to V0 + NN)